### PR TITLE
add an alternative sorting method

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,7 @@ This is useful in case you have for instance sizes like kb, Mb, GB, etc.
   </tbody>
 </table>
 ```
+
+If you click on a table header while holding shift or alt an alternative 
+`data-sort-alt` attribute is used for sorting if available and the usual 
+`data-sort` otherwise.

--- a/sortable.js
+++ b/sortable.js
@@ -45,6 +45,7 @@ document.addEventListener('click', function (e) {
   var regex_dir = / dir-(u|d) /
   var regex_table = /\bsortable\b/
   var element = e.target
+  var alt_sort = e.shiftKey || e.altKey
 
   function reClassify(element, dir) {
     element.className = element.className.replace(regex_dir, '') + dir
@@ -53,7 +54,7 @@ document.addEventListener('click', function (e) {
   function getValue(element) {
     // If you aren't using data-sort and want to make it just the tiniest bit smaller/faster
     // comment this line and uncomment the next one
-    return element.getAttribute('data-sort') || element.innerText
+    return alt_sort && element.getAttribute('data-sort-alt') || element.getAttribute('data-sort') || element.innerText
     // return element.innerText
   }
 


### PR DESCRIPTION
Alternative sorting method via click + shift/alt and the data-sort-alt attribute.

## Purpose

I found a use case where a column has a numerical `data-sort` but sometimes it would be useful to sort just by the bool value of that numerical value.

## Approach

Added the `data-sort-alt` attribute with automatic fallback to `data-sort`.

## Fixes

The PR itself.