### PR TITLE
Support clicking on child elements of th

### DIFF
--- a/sortable.js
+++ b/sortable.js
@@ -58,6 +58,14 @@ document.addEventListener('click', function (e) {
     // return element.innerText
   }
 
+  // Support clicking on child elements, e.g. icons
+  while (element.nodeName !== 'TH') {
+    element = element.parentNode
+    if (element.nodeName === 'HTML') {
+      break
+    }
+  }
+
   if (element.nodeName === 'TH') {
     try {
       var tr = element.parentNode


### PR DESCRIPTION
# Support clicking on child elements of th

## Purpose

If the content of the TH is an icon (fontawesome, iconify svg..) the sorting won't trigger, as the click target often isn't the TH but instead a SPAN or SVG child.

## Approach

With this change the parents of the element will be iterated until either TH or HTML (on which the loop breaks) has been found.
I've used a while loop instead of just checking the first parentNode because with svg icons there'll be multiple child elements on which the click can register.

## Concerns
This has been working great for my use case, but there may be performance issues with deeply nested html?

